### PR TITLE
Adding -api artifact, due to broken build

### DIFF
--- a/proposals/streams/microprofile-streams-example/pom.xml
+++ b/proposals/streams/microprofile-streams-example/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-</artifactId>
+            <artifactId>slf4j-api</artifactId>
             <version>1.7.12</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
@jroper hey james, looks like there was a _typo_ on the pom... I just added the `-api` artifact of the _slf4j_ logger