### PR TITLE
Automatically put containers on the same network if no networks specified

### DIFF
--- a/proposals/system-test/core/build.gradle
+++ b/proposals/system-test/core/build.gradle
@@ -32,6 +32,6 @@ dependencies {
   compile group: 'org.apache.cxf', name: 'cxf-rt-rs-extension-providers', version: '3.3.0'
   compile group: 'javax.inject', name: 'javax.inject', version: '1'
   compile "org.testcontainers:junit-jupiter:1.11.2"
-  compile 'com.github.testcontainers:mp-jee-testing:0.2-alpha'
+  compile 'com.github.testcontainers.mp-jee-testing:mp-jee-testing-core:v0.3-alpha'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
 }

--- a/proposals/system-test/core/build.gradle
+++ b/proposals/system-test/core/build.gradle
@@ -32,6 +32,6 @@ dependencies {
   compile group: 'org.apache.cxf', name: 'cxf-rt-rs-extension-providers', version: '3.3.0'
   compile group: 'javax.inject', name: 'javax.inject', version: '1'
   compile "org.testcontainers:junit-jupiter:1.11.2"
-  compile 'com.github.testcontainers.mp-jee-testing:mp-jee-testing-core:v0.3-alpha'
+  compile 'com.github.testcontainers.mp-jee-testing:mp-jee-testing-core:master-SNAPSHOT'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
 }

--- a/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jaxrs/JAXRSUtilities.java
+++ b/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jaxrs/JAXRSUtilities.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019 IBM Corporation and others
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.system.test.jaxrs;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JAXRSUtilities {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(JAXRSUtilities.class);
+
+    public static <T> T createRestClient(Class<T> clazz, String appContextRoot, String applicationPath) {
+        Objects.requireNonNull(appContextRoot, "Supplied 'appContextRoot' must not be null");
+        Objects.requireNonNull(applicationPath, "Supplied 'applicationPath' must not be null");
+        String basePath = join(appContextRoot, applicationPath);
+        // TODO: Allow the provider list to be customized
+        List<Class<?>> providers = Collections.singletonList(JsonBProvider.class);
+        LOGGER.info("Building rest client for " + clazz + " with base path: " + basePath + " and providers: " + providers);
+        return JAXRSClientFactory.create(basePath, clazz, providers);
+    }
+
+    public static <T> T createRestClient(Class<T> clazz, String appContextRoot) {
+        String resourcePackage = clazz.getPackage().getName();
+
+        // First check for a javax.ws.rs.core.Application in the same package as the resource
+        List<Class<?>> appClasses = ReflectionSupport.findAllClassesInPackage(resourcePackage,
+                                                                              c -> Application.class.isAssignableFrom(c) &&
+                                                                                   AnnotationSupport.isAnnotated(c, ApplicationPath.class),
+                                                                              n -> true);
+        if (appClasses.size() == 0) {
+            // If not found, check under the 3rd package, so com.foo.bar.*
+            // Classpath scanning can be expensive, so we jump straight to the 3rd package from root instead
+            // of recursing up one package at a time and scanning the entire CP for each step
+            String[] pkgs = resourcePackage.split("(.*)\\.(.*)\\.(.*)\\.", 2);
+            if (pkgs.length > 0 && !pkgs[0].isEmpty() && !pkgs[0].equals(resourcePackage)) {
+                appClasses = ReflectionSupport.findAllClassesInPackage(pkgs[0],
+                                                                       c -> Application.class.isAssignableFrom(c) &&
+                                                                            AnnotationSupport.isAnnotated(c, ApplicationPath.class),
+                                                                       n -> true);
+            }
+        }
+
+        if (appClasses.size() == 0) {
+            LOGGER.info("No classes implementing 'javax.ws.rs.core.Application' found on classpath to set as context root for " + clazz +
+                        ". Defaulting context root to '/'");
+            return createRestClient(clazz, appContextRoot, "");
+        }
+
+        Class<?> selectedClass = appClasses.get(0);
+        if (appClasses.size() > 1) {
+            appClasses.sort((c1, c2) -> c1.getCanonicalName().compareTo(c2.getCanonicalName()));
+            LOGGER.warn("Found multiple classes implementing 'javax.ws.rs.core.Application' on classpath: " + appClasses +
+                        ". Setting context root to the first class discovered (" + selectedClass.getCanonicalName() + ")");
+        }
+        ApplicationPath appPath = AnnotationSupport.findAnnotation(selectedClass, ApplicationPath.class).get();
+        return createRestClient(clazz, appContextRoot, appPath.value());
+    }
+
+    private static String join(String firstPart, String secondPart) {
+        if (firstPart.endsWith("/") && secondPart.startsWith("/"))
+            return firstPart + secondPart.substring(1);
+        else if (firstPart.endsWith("/") || secondPart.startsWith("/"))
+            return firstPart + secondPart;
+        else
+            return firstPart + "/" + secondPart;
+    }
+
+}

--- a/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jaxrs/JsonBProvider.java
+++ b/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jaxrs/JsonBProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019 IBM Corporation and others
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.system.test.jaxrs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Scanner;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+@Produces({ "*/*" })
+@Consumes({ "*/*" })
+public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyReader<Object> {
+
+    private static final Jsonb jsonb = JsonbBuilder.create();
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonBProvider.class);
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public Object readFrom(Class<Object> clazz, Type genericType, Annotation[] annotations,
+                           MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        String stringResult = convertStreamToString(entityStream);
+        LOGGER.info("Response from server: " + stringResult);
+        return jsonb.fromJson(stringResult, genericType);
+    }
+
+    @SuppressWarnings("resource")
+    private static String convertStreamToString(java.io.InputStream is) {
+        try (Scanner s = new Scanner(is).useDelimiter("\\A")) {
+            return s.hasNext() ? s.next() : "";
+        }
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public void writeTo(Object obj, Class<?> type, Type genericType, Annotation[] annotations,
+                        MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        String strData = jsonb.toJson(obj);
+        LOGGER.info("Sending data to server: " + strData);
+        jsonb.toJson(obj, entityStream);
+    }
+}

--- a/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jupiter/MicroProfileTestExtension.java
+++ b/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jupiter/MicroProfileTestExtension.java
@@ -20,23 +20,18 @@ package org.eclipse.microprofile.system.test.jupiter;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.system.test.jaxrs.JAXRSUtilities;
+import org.eclipse.microprofile.system.test.testcontainers.TestcontainersConfiguration;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
-import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.microprofile.MicroProfileApplication;
-import org.testcontainers.junit.jupiter.Container;
 
 /**
  * JUnit Jupiter extension that is applied whenever the <code>@MicroProfileTest</code> is used on a test class.
@@ -49,125 +44,32 @@ public class MicroProfileTestExtension implements BeforeAllCallback {
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        processSharedContainerConfig(context);
-        injectRestClients(context);
+        Class<?> testClass = context.getRequiredTestClass();
+        // For now this is hard-coded to using Testcontainers for container management.
+        // In the future, this could be configurable to something besides Testcontainers
+        TestcontainersConfiguration config = new TestcontainersConfiguration(testClass);
+        config.applyConfiguration();
+        config.startContainers();
+        injectRestClients(testClass, config);
     }
 
-    private static void processSharedContainerConfig(ExtensionContext context) throws IllegalArgumentException, IllegalAccessException {
-        Class<?> clazz = context.getRequiredTestClass();
-        if (!clazz.isAnnotationPresent(SharedContainerConfig.class))
-            return;
-
-        Class<? extends SharedContainerConfiguration> configClass = clazz.getAnnotation(SharedContainerConfig.class).value();
-
-        Set<GenericContainer<?>> discoveredContaienrs = new HashSet<>();
-        for (Field containerField : AnnotationSupport.findAnnotatedFields(configClass, Container.class)) {
-            if (!Modifier.isStatic(containerField.getModifiers()) || !Modifier.isPublic(containerField.getModifiers()))
-                continue;
-            boolean isStartable = GenericContainer.class.isAssignableFrom(containerField.getType());
-            if (!isStartable)
-                throw new ExtensionConfigurationException("Annotation is only supported for " + GenericContainer.class + " types");
-            GenericContainer<?> startableContainer = (GenericContainer<?>) containerField.get(null);
-            discoveredContaienrs.add(startableContainer);
-        }
-
-        // Put all containers in the same network if no networks are explicitly defined
-        boolean networksDefined = false;
-        for (GenericContainer<?> c : discoveredContaienrs)
-            networksDefined |= c.getNetwork() != null;
-        if (!networksDefined) {
-            LOGGER.debug("No networks explicitly defined. Using shared network for all containers.");
-            discoveredContaienrs.forEach(c -> c.setNetwork(Network.SHARED));
-        }
-
-        // Check if the SharedContainerConfig has implemented a manual container start
-        // TODO: Merge this behavior with non-SharedContainerConfig usage of @Container
-        try {
-            SharedContainerConfiguration configInstance = configClass.newInstance();
-            configInstance.startContainers();
-            return;
-        } catch (UnsupportedOperationException tolerable) {
-        } catch (InstantiationException e) {
-            throw new ExtensionConfigurationException("Problem creating new instance of class: " + configClass, e);
-        }
-
-        // If we get here, the user has not implemented a custom startContainers() method
-        Set<GenericContainer<?>> containersToStart = new HashSet<>();
-        for (GenericContainer<?> c : discoveredContaienrs) {
-            if (!c.isRunning()) {
-                containersToStart.add(c);
-            } else {
-                LOGGER.info("Found already running contianer instance: " + c.getContainerId());
-            }
-        }
-
-        if (containersToStart.isEmpty())
-            return;
-
-        LOGGER.info("Starting containers in parallel for " + configClass);
-        for (GenericContainer<?> c : containersToStart)
-            LOGGER.info("  " + c.getImage());
-        long start = System.currentTimeMillis();
-        containersToStart.parallelStream().forEach(GenericContainer::start);
-        LOGGER.info("All containers started in " + (System.currentTimeMillis() - start) + "ms");
-    }
-
-    private static void injectRestClients(ExtensionContext context) throws Exception {
-        Class<?> clazz = context.getRequiredTestClass();
+    private static void injectRestClients(Class<?> clazz, TestcontainersConfiguration config) throws Exception {
         List<Field> restClientFields = AnnotationSupport.findAnnotatedFields(clazz, Inject.class);
         if (restClientFields.size() == 0)
             return;
 
-        MicroProfileApplication<?> mpApp = autoDiscoverMPApp(clazz, true);
-
-        // At this point we have found exactly one MicroProfileApplication -- proceed with auto-configure
-        if (!mpApp.isCreated() || !mpApp.isRunning())
-            throw new ExtensionConfigurationException("Container " + mpApp.getDockerImageName() + " is not running yet. "
-                                                      + "It should have been started by the @Testcontainers extension. "
-                                                      + "TIP: Make sure that you list @TestContainers before @MicroProfileTest!");
+        String mpAppURL = config.getApplicationURL();
 
         for (Field restClientField : restClientFields) {
-            checkPublicStaticNonFinal(restClientField);
-            Object restClient = mpApp.createRestClient(restClientField.getType());
+            if (!Modifier.isPublic(restClientField.getModifiers()) ||
+                !Modifier.isStatic(restClientField.getModifiers()) ||
+                Modifier.isFinal(restClientField.getModifiers())) {
+                throw new ExtensionConfigurationException("REST-client field must be public, static, and non-final: " + restClientField.getName());
+            }
+
+            Object restClient = JAXRSUtilities.createRestClient(restClientField.getType(), mpAppURL);
             restClientField.set(null, restClient);
             LOGGER.debug("Injecting rest client for " + restClientField);
         }
     }
-
-    private static MicroProfileApplication<?> autoDiscoverMPApp(Class<?> testClass, boolean errorIfNone) throws IllegalArgumentException, IllegalAccessException {
-        // First check for any MicroProfileApplicaiton directly present on the test class
-        List<Field> mpApps = AnnotationSupport.findAnnotatedFields(testClass, Container.class,
-                                                                   f -> Modifier.isStatic(f.getModifiers()) &&
-                                                                        Modifier.isPublic(f.getModifiers()) &&
-                                                                        MicroProfileApplication.class.isAssignableFrom(f.getType()),
-                                                                   HierarchyTraversalMode.TOP_DOWN);
-        if (mpApps.size() == 1)
-            return (MicroProfileApplication<?>) mpApps.get(0).get(null);
-        if (mpApps.size() > 1)
-            throw new ExtensionConfigurationException("Should be no more than 1 public static MicroProfileApplication field on " + testClass);
-
-        // If none found, check any SharedContainerConfig
-        String sharedConfigMsg = "";
-        if (testClass.isAnnotationPresent(SharedContainerConfig.class)) {
-            Class<? extends SharedContainerConfiguration> configClass = testClass.getAnnotation(SharedContainerConfig.class).value();
-            MicroProfileApplication<?> mpApp = autoDiscoverMPApp(configClass, false);
-            if (mpApp != null)
-                return mpApp;
-            sharedConfigMsg = " or " + configClass;
-        }
-
-        if (errorIfNone)
-            throw new ExtensionConfigurationException("No public static MicroProfileApplication fields annotated with @Container were located " +
-                                                      "on " + testClass + sharedConfigMsg + " to auto-connect with @RestClient fields.");
-        return null;
-    }
-
-    private static void checkPublicStaticNonFinal(Field f) {
-        if (!Modifier.isPublic(f.getModifiers()) ||
-            !Modifier.isStatic(f.getModifiers()) ||
-            Modifier.isFinal(f.getModifiers())) {
-            throw new ExtensionConfigurationException("@RestClient annotated field must be public, static, and non-final: " + f.getName());
-        }
-    }
-
 }

--- a/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jupiter/MicroProfileTestExtension.java
+++ b/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/jupiter/MicroProfileTestExtension.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.aguibert.testcontainers.framework.MicroProfileApplication;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -35,6 +34,7 @@ import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 
 /**

--- a/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/testcontainers/TestcontainersConfiguration.java
+++ b/proposals/system-test/core/src/main/java/org/eclipse/microprofile/system/test/testcontainers/TestcontainersConfiguration.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019 IBM Corporation and others
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.system.test.testcontainers;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfig;
+import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfiguration;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
+import org.testcontainers.junit.jupiter.Container;
+
+public class TestcontainersConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestcontainersConfiguration.class);
+
+    private final Class<?> testClass;
+    private Class<? extends SharedContainerConfiguration> sharedConfigClass;
+    private final Set<GenericContainer<?>> unsharedContainers = new HashSet<>();
+    private final Set<GenericContainer<?>> sharedContainers = new HashSet<>();
+
+    public TestcontainersConfiguration(Class<?> testClass) {
+        this.testClass = testClass;
+
+        if (testClass.isAnnotationPresent(SharedContainerConfig.class)) {
+            sharedConfigClass = testClass.getAnnotation(SharedContainerConfig.class).value();
+            sharedContainers.addAll(discoverContainers(sharedConfigClass));
+        }
+        unsharedContainers.addAll(discoverContainers(testClass));
+    }
+
+    public void applyConfiguration() {
+        // Put all containers in the same network if no networks are explicitly defined
+        boolean networksDefined = false;
+        if (sharedConfigClass != null) {
+            for (GenericContainer<?> c : sharedContainers)
+                networksDefined |= c.getNetwork() != null;
+            if (!networksDefined) {
+                LOG.debug("No networks explicitly defined. Using shared network for all containers in " + sharedConfigClass);
+                sharedContainers.forEach(c -> c.setNetwork(Network.SHARED));
+            }
+        }
+
+        networksDefined = false;
+        for (GenericContainer<?> c : unsharedContainers)
+            networksDefined |= c.getNetwork() != null;
+        if (!networksDefined) {
+            LOG.debug("No networks explicitly defined. Using shared network for all containers in " + testClass);
+            unsharedContainers.forEach(c -> c.setNetwork(Network.SHARED));
+        }
+    }
+
+    public void startContainers() {
+        Set<GenericContainer<?>> containersToStart = new HashSet<>();
+        containersToStart.addAll(sharedContainers);
+        containersToStart.addAll(unsharedContainers);
+        containersToStart.removeIf(c -> c.isRunning());
+
+        LOG.info("Starting containers in parallel for " + testClass);
+        for (GenericContainer<?> c : containersToStart)
+            LOG.info("  " + c.getImage());
+        long start = System.currentTimeMillis();
+        containersToStart.parallelStream().forEach(GenericContainer::start);
+        LOG.info("All containers started in " + (System.currentTimeMillis() - start) + "ms");
+    }
+
+    public String getApplicationURL() {
+        MicroProfileApplication<?> mpApp = autoDiscoverMPApp(testClass, true);
+
+        // At this point we have found exactly one MicroProfileApplication
+        if (!mpApp.isCreated() || !mpApp.isRunning())
+            throw new ExtensionConfigurationException("MicroProfileApplication " + mpApp.getDockerImageName() + " is not running yet. " +
+                                                      "The contianer must be running in order to obtain its URL.");
+
+        return mpApp.getApplicationURL();
+    }
+
+    private MicroProfileApplication<?> autoDiscoverMPApp(Class<?> clazz, boolean errorIfNone) {
+        // First check for any MicroProfileApplicaiton directly present on the test class
+        List<Field> mpApps = AnnotationSupport.findAnnotatedFields(clazz, Container.class,
+                                                                   f -> Modifier.isStatic(f.getModifiers()) &&
+                                                                        Modifier.isPublic(f.getModifiers()) &&
+                                                                        MicroProfileApplication.class.isAssignableFrom(f.getType()),
+                                                                   HierarchyTraversalMode.TOP_DOWN);
+        if (mpApps.size() == 1)
+            try {
+                return (MicroProfileApplication<?>) mpApps.get(0).get(null);
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                // This should never happen because we only look for fields that are public+static
+                e.printStackTrace();
+            }
+        if (mpApps.size() > 1)
+            throw new ExtensionConfigurationException("Should be no more than 1 public static MicroProfileApplication field on " + clazz);
+
+        // If none found, check any SharedContainerConfig
+        String sharedConfigMsg = "";
+        if (sharedConfigClass != null) {
+            MicroProfileApplication<?> mpApp = autoDiscoverMPApp(sharedConfigClass, false);
+            if (mpApp != null)
+                return mpApp;
+            sharedConfigMsg = " or " + sharedConfigClass;
+        }
+
+        if (errorIfNone)
+            throw new ExtensionConfigurationException("No public static MicroProfileApplication fields annotated with @Container were located " +
+                                                      "on " + clazz + sharedConfigMsg + " to auto-connect with REST-client fields.");
+        return null;
+    }
+
+    private Set<GenericContainer<?>> discoverContainers(Class<?> clazz) {
+        Set<GenericContainer<?>> discoveredContainers = new HashSet<>();
+        for (Field containerField : AnnotationSupport.findAnnotatedFields(clazz, Container.class)) {
+            if (!Modifier.isPublic(containerField.getModifiers()))
+                throw new ExtensionConfigurationException("@Container annotated fields must be public visibility");
+            if (!Modifier.isStatic(containerField.getModifiers()))
+                throw new ExtensionConfigurationException("@Container annotated fields must be static");
+            boolean isStartable = GenericContainer.class.isAssignableFrom(containerField.getType());
+            if (!isStartable)
+                throw new ExtensionConfigurationException("@Container annotated fields must be a subclass of " + GenericContainer.class);
+            try {
+                GenericContainer<?> startableContainer = (GenericContainer<?>) containerField.get(null);
+                discoveredContainers.add(startableContainer);
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                LOG.warn("Unable to access field " + containerField, e);
+            }
+        }
+        return discoveredContainers;
+    }
+
+}

--- a/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
+++ b/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
@@ -21,7 +21,6 @@ package org.eclipse.microprofile.system.test.app;
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfiguration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
-import org.testcontainers.containers.Network;
 import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 
@@ -29,7 +28,6 @@ public class AppContainerConfig implements SharedContainerConfiguration {
 
     @Container
     public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
-                    .withNetwork(Network.SHARED)
                     .withAppContextRoot("/myservice")
                     .withEnv("MONGO_HOSTNAME", "testmongo")
                     .withEnv("MONGO_PORT", "27017")
@@ -37,12 +35,10 @@ public class AppContainerConfig implements SharedContainerConfiguration {
 
     @Container
     public static MockServerContainer mockServer = new MockServerContainer()
-                    .withNetwork(Network.SHARED)
                     .withNetworkAliases("mockserver");
 
     @Container
     public static GenericContainer<?> mongo = new GenericContainer<>("mongo:3.4")
-                    .withNetwork(Network.SHARED)
                     .withNetworkAliases("testmongo");
 
     @Override

--- a/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
+++ b/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
@@ -18,13 +18,11 @@
  */
 package org.eclipse.microprofile.system.test.app;
 
-import java.time.Duration;
-
-import org.aguibert.testcontainers.framework.MicroProfileApplication;
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfiguration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 
 public class AppContainerConfig implements SharedContainerConfiguration {
@@ -33,7 +31,6 @@ public class AppContainerConfig implements SharedContainerConfiguration {
     public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
                     .withNetwork(Network.SHARED)
                     .withAppContextRoot("/myservice")
-                    .withStartupTimeout(Duration.ofSeconds(30))
                     .withEnv("MONGO_HOSTNAME", "testmongo")
                     .withEnv("MONGO_PORT", "27017")
                     .withMpRestClient(ExternalRestServiceClient.class, "http://mockserver:" + MockServerContainer.PORT);
@@ -51,9 +48,11 @@ public class AppContainerConfig implements SharedContainerConfiguration {
     @Override
     public void startContainers() {
         // OPTIONAL: this method may be implemented to do custom instantiation/ordering of containers
-        mongo.start();
-        mockServer.start();
-        app.start();
+//        mongo.start();
+//        mockServer.start();
+//        app.start();
+        // by default evertything will start in parallel
+        SharedContainerConfiguration.super.startContainers();
     }
 
 }

--- a/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/BasicJAXRSServiceTest.java
+++ b/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/BasicJAXRSServiceTest.java
@@ -29,14 +29,10 @@ import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
-import org.eclipse.microprofile.system.test.app.Person;
-import org.eclipse.microprofile.system.test.app.PersonService;
 import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfig;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @MicroProfileTest
 @SharedContainerConfig(AppContainerConfig.class)
 public class BasicJAXRSServiceTest {

--- a/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/DependentServiceTest.java
+++ b/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/DependentServiceTest.java
@@ -27,19 +27,15 @@ import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
-import org.eclipse.microprofile.system.test.app.Person;
-import org.eclipse.microprofile.system.test.app.PersonServiceWithPassthrough;
 import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfig;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.google.common.net.MediaType;
 
 @SuppressWarnings("resource")
 
-@Testcontainers
 @MicroProfileTest
 @SharedContainerConfig(AppContainerConfig.class)
 public class DependentServiceTest {

--- a/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/DynamicallyLayeredTest.java
+++ b/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/DynamicallyLayeredTest.java
@@ -22,12 +22,11 @@ import static org.junit.Assert.assertNotNull;
 
 import javax.inject.Inject;
 
-import org.aguibert.testcontainers.framework.ComposedMicroProfileApplication;
-import org.aguibert.testcontainers.framework.MicroProfileApplication;
-import org.eclipse.microprofile.system.test.app.PersonService;
 import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.microprofile.ComposedMicroProfileApplication;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 

--- a/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/DynamicallyLayeredTest.java
+++ b/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/DynamicallyLayeredTest.java
@@ -28,9 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.microprofile.ComposedMicroProfileApplication;
 import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @MicroProfileTest
 @Disabled // not a golden path test
 public class DynamicallyLayeredTest {

--- a/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/MongoAndLibertyTest.java
+++ b/proposals/system-test/sample-apps/everything-app/src/test/java/org/eclipse/microprofile/system/test/app/MongoAndLibertyTest.java
@@ -25,14 +25,10 @@ import java.util.Collection;
 
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.system.test.app.Person;
-import org.eclipse.microprofile.system.test.app.PersonServiceWithMongo;
 import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfig;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @MicroProfileTest
 @SharedContainerConfig(AppContainerConfig.class)
 public class MongoAndLibertyTest {

--- a/proposals/system-test/sample-apps/everything-app/src/test/resources/log4j.properties
+++ b/proposals/system-test/sample-apps/everything-app/src/test/resources/log4j.properties
@@ -7,4 +7,4 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%r %p %c %x - %m%n
 
-log4j.logger.org.aguibert.liberty=DEBUG
+log4j.logger.org.eclipse.microprofile.system.test=DEBUG

--- a/proposals/system-test/sample-apps/jaxrs-json/src/test/java/org/eclipse/microprofile/system/test/app/JaxrsJsonTest.java
+++ b/proposals/system-test/sample-apps/jaxrs-json/src/test/java/org/eclipse/microprofile/system/test/app/JaxrsJsonTest.java
@@ -30,11 +30,11 @@ import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
-import org.aguibert.testcontainers.framework.MicroProfileApplication;
 import org.eclipse.microprofile.system.test.app.Person;
 import org.eclipse.microprofile.system.test.app.PersonService;
 import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -45,7 +45,6 @@ public class JaxrsJsonTest {
     @Container
     public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
                     .withAppContextRoot("/myservice")
-                    .withStartupTimeout(Duration.ofSeconds(30))
                     .withReadinessPath("/myservice/app/people");
 
     @Inject

--- a/proposals/system-test/sample-apps/jaxrs-json/src/test/java/org/eclipse/microprofile/system/test/app/JaxrsJsonTest.java
+++ b/proposals/system-test/sample-apps/jaxrs-json/src/test/java/org/eclipse/microprofile/system/test/app/JaxrsJsonTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.time.Duration;
 import java.util.Collection;
 
 import javax.inject.Inject;
@@ -36,9 +35,7 @@ import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @MicroProfileTest
 public class JaxrsJsonTest {
     

--- a/proposals/system-test/sample-apps/jaxrs-json/src/test/resources/log4j.properties
+++ b/proposals/system-test/sample-apps/jaxrs-json/src/test/resources/log4j.properties
@@ -7,4 +7,4 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%r %p %c %x - %m%n
 
-log4j.logger.org.aguibert.liberty=DEBUG
+log4j.logger.org.eclipse.microprofile.system.test=DEBUG

--- a/proposals/system-test/sample-apps/jdbc-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
+++ b/proposals/system-test/sample-apps/jdbc-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
@@ -18,10 +18,10 @@
  */
 package org.eclipse.microprofile.system.test.app;
 
-import org.aguibert.testcontainers.framework.MicroProfileApplication;
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfiguration;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 
 /**

--- a/proposals/system-test/sample-apps/jdbc-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
+++ b/proposals/system-test/sample-apps/jdbc-app/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
@@ -19,26 +19,20 @@
 package org.eclipse.microprofile.system.test.app;
 
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfiguration;
-import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 
-/**
- * @author aguibert
- */
 public class AppContainerConfig implements SharedContainerConfiguration {
 
     @Container
     public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
-					.withNetwork(Network.SHARED)
 					.withEnv("POSTGRES_HOSTNAME", "testpostgres")
                     .withEnv("POSTGRES_PORT", "5432")
                     .withAppContextRoot("/myservice");
 					
 	@Container
 	public static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>()
-					.withNetwork(Network.SHARED)
 					.withNetworkAliases("testpostgres")
 					.withDatabaseName("testdb");	
 

--- a/proposals/system-test/sample-apps/jdbc-app/src/test/java/org/eclipse/microprofile/system/test/app/DatabaseTest.java
+++ b/proposals/system-test/sample-apps/jdbc-app/src/test/java/org/eclipse/microprofile/system/test/app/DatabaseTest.java
@@ -30,9 +30,7 @@ import org.eclipse.microprofile.system.test.app.PersonServiceWithJDBC;
 import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.eclipse.microprofile.system.test.jupiter.SharedContainerConfig;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @MicroProfileTest
 @SharedContainerConfig(AppContainerConfig.class)
 public class DatabaseTest {

--- a/proposals/system-test/sample-apps/jdbc-app/src/test/resources/log4j.properties
+++ b/proposals/system-test/sample-apps/jdbc-app/src/test/resources/log4j.properties
@@ -7,4 +7,4 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%r %p %c %x - %m%n
 
-log4j.logger.org.aguibert.liberty=DEBUG
+log4j.logger.org.eclipse.microprofile.system.test=DEBUG

--- a/proposals/system-test/sample-apps/maven-app/build.gradle
+++ b/proposals/system-test/sample-apps/maven-app/build.gradle
@@ -29,7 +29,7 @@ task runMvnVerify(type:Exec) {
   }
 }
 
-assemble.dependsOn project(':microprofile-system-test-core').publishToMavenLocal
+compileJava.dependsOn project(':microprofile-system-test-core').publishToMavenLocal
 assemble.dependsOn runMvnCompile
 test.dependsOn runMvnVerify
 

--- a/proposals/system-test/sample-apps/maven-app/build.gradle
+++ b/proposals/system-test/sample-apps/maven-app/build.gradle
@@ -1,0 +1,38 @@
+// Disable gradle compile/test for this project so Maven can handle it
+sourceSets {
+    main.java.srcDirs = []
+    main.resources.srcDirs = []
+    test.java.srcDirs = []
+    test.resources.srcDirs = []
+}
+
+task runMvnCompile(type:Exec) {
+  environment System.getProperties()
+  if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+    executable "cmd"
+    args '/c', 'mvn', "clean", 'compile'
+  } else {
+    executable "mvn"
+    args 'clean', 'compile'
+  }
+}
+
+task runMvnVerify(type:Exec) {
+  shouldRunAfter runMvnCompile
+  environment System.getProperties()
+  if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+    executable "cmd"
+    args '/c', 'mvn', "clean", 'verify'
+  } else {
+    executable "mvn"
+    args 'clean', 'verify'
+  }
+}
+
+assemble.dependsOn project(':microprofile-system-test-core').publishToMavenLocal
+assemble.dependsOn runMvnCompile
+test.dependsOn runMvnVerify
+
+// Always re-run tests on every build for the sake of this sample
+// In a real project, this setting would not be desirable
+test.outputs.upToDateWhen { false } 

--- a/proposals/system-test/sample-apps/maven-app/src/test/java/org/eclipse/microprofile/system/test/app/it/JaxrsJsonTest.java
+++ b/proposals/system-test/sample-apps/maven-app/src/test/java/org/eclipse/microprofile/system/test/app/it/JaxrsJsonTest.java
@@ -37,7 +37,6 @@ import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @MicroProfileTest
 public class JaxrsJsonTest {
     

--- a/proposals/system-test/sample-apps/maven-app/src/test/java/org/eclipse/microprofile/system/test/app/it/JaxrsJsonTest.java
+++ b/proposals/system-test/sample-apps/maven-app/src/test/java/org/eclipse/microprofile/system/test/app/it/JaxrsJsonTest.java
@@ -29,11 +29,11 @@ import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
-import org.aguibert.testcontainers.framework.MicroProfileApplication;
 import org.eclipse.microprofile.system.test.app.Person;
 import org.eclipse.microprofile.system.test.app.PersonService;
 import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 

--- a/proposals/system-test/sample-apps/maven-app/src/test/resources/log4j.properties
+++ b/proposals/system-test/sample-apps/maven-app/src/test/resources/log4j.properties
@@ -7,4 +7,4 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%r %p %c %x - %m%n
 
-log4j.logger.org.aguibert.liberty=DEBUG
+log4j.logger.org.eclipse.microprofile.system.test=DEBUG

--- a/proposals/system-test/settings.gradle
+++ b/proposals/system-test/settings.gradle
@@ -11,9 +11,6 @@ file('modules').eachDir { dir ->
 
 // Include all test app projects as microprofile-system-test-<APP_NAME>
 file('sample-apps').eachDir { dir ->
-    // Do not include maven projects as gradle projects
-    if (dir.name.contains("maven"))
-      return;
     include 'microprofile-system-test-' + dir.name
     project(':microprofile-system-test-' + dir.name).projectDir = dir
 }

--- a/proposals/system-test/settings.gradle
+++ b/proposals/system-test/settings.gradle
@@ -3,12 +3,6 @@ rootProject.name = 'system-test'
 include "microprofile-system-test-core"
 project(':microprofile-system-test-core').projectDir = "$rootDir/core" as File
 
-// Include all modules as microprofile-system-test-<MODULE>
-file('modules').eachDir { dir ->
-    include 'microprofile-system-test-' + dir.name
-    project(':microprofile-system-test-' + dir.name).projectDir = dir
-}
-
 // Include all test app projects as microprofile-system-test-<APP_NAME>
 file('sample-apps').eachDir { dir ->
     include 'microprofile-system-test-' + dir.name


### PR DESCRIPTION
Normally if multiple contains are to communicate with each other, they need to be on the same Docker `Network`, which looks something like this:
```java
    @Container
    public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
                    .withNetwork(Network.SHARED)
                    // ...

    @Container
    public static MockServerContainer mockServer = new MockServerContainer()
                    .withNetwork(Network.SHARED)
                    // ...

    @Container
    public static GenericContainer<?> mongo = new GenericContainer<>("mongo:3.4")
                    .withNetwork(Network.SHARED)
                    // ...
```

This can be non-obvious for new users, and typically if multiple containers are defined in the same class, it is reasonable to expect that they may need to communicate with each other. Or at least, not be an issue if they are able to communicate with each other.

This PR eliminates boiler plate by placing all containers on the `Network.SHARED` network if no networks are explicitly defined on any of the containers. Simplifying the above code example to:
```java
    @Container
    public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
                    // ...

    @Container
    public static MockServerContainer mockServer = new MockServerContainer()
                    // ...

    @Container
    public static GenericContainer<?> mongo = new GenericContainer<>("mongo:3.4")
                    // ...
```