### PR TITLE
Update microprofile-standalone-working-group-proposal.adoc

### DIFF
--- a/proposals/working-group/microprofile-working-group/microprofile-standalone-working-group-proposal.adoc
+++ b/proposals/working-group/microprofile-working-group/microprofile-standalone-working-group-proposal.adoc
@@ -52,5 +52,5 @@ Our preference is to establish a minimalistic Working Group, with low overhead a
 ** All specifications developed within a single Eclipse project by default
 * Marketing
 Encourage brand proliferation
-** Eclipse Foundation and Working Group members retain and manage admin access on all social media accounts
+Working Group members retain and manage admin access on all social media accounts
 ** A well-defined set of logo usage rules will be established. All requests for MicroProfile Logo usage outside those rules must be directed to MicroProfile Working Group.


### PR DESCRIPTION
Today the MP media is managed the the active Microprofilers, not EF. 
This is scalable and makes our community handsON and much aware of how much it matters to participate from zero.  Further, it avoids the deadly expense of hiring human brains under the EF umbrella, not friendly to OSS for potential new partners and current community.