### PR TITLE
Fix sponsorship.adoc file name

### DIFF
--- a/proposals/working-group/microprofile-working-group/microprofile-standalone-working-group-proposal.adoc
+++ b/proposals/working-group/microprofile-working-group/microprofile-standalone-working-group-proposal.adoc
@@ -54,3 +54,5 @@ Our preference is to establish a minimalistic Working Group, with low overhead a
 Encourage brand proliferation
 ** Eclipse Foundation and Working Group members retain and manage admin access on all social media accounts
 ** A well-defined set of logo usage rules will be established. All requests for MicroProfile Logo usage outside those rules must be directed to MicroProfile Working Group.
+
+include::sponsorship.adoc[leveloffset=+1]

--- a/proposals/working-group/microprofile-working-group/sponsorship.adoc
+++ b/proposals/working-group/microprofile-working-group/sponsorship.adoc
@@ -25,6 +25,8 @@ as given in the following table:
 |$  1,000| Nonprofit, university, local or government 
 |====================
 
+Project sponsors also typically support specification developers that work on the specification
+committee and specification projects.
 
 == Specification Sponsors
 Specification sponsors provide specification committee members and project members from their


### PR DESCRIPTION
Add statement that project sponsors typically are specficiation sponsors as well.

Signed-off-by: Scott M Stark <starksm64@gmail.com>