### PR TITLE
Suggestion: Java standard for problem details [rfc-7807]

### DIFF
--- a/proposals/problem-details/README.asciidoc
+++ b/proposals/problem-details/README.asciidoc
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2019 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+= Problem Details
+
+//The specification is here
+//TODO provide link the the spec html
+
+== About
+
+The proposed standard https://tools.ietf.org/html/rfc7807[RFC-7807] specifies an http response message entity (body) to convey the machine- and human-readable details about a problem with a request. In order to apply this standard to the Java world, exceptions on the server side have to be mapped to such a problem details; and/or problem detail responses have to trigger an exception on the client side containing the information provided in the message.
+
+The MicroProfile Problem Detail specification defines that compliant implementations:
+
+* Map exceptions thrown while processing an http request to valid problem detail documents.
+* What defaults to use for the various specified fields.
+* Consider the annotations defined in the API to override those details or add extension fields.
+* On the client side map problem detail http message entities back to appropriate standard or a (compatible) custom exceptions containing the fields and extensions.
+
+
+== Building
+
+Just enter `mvn` at the command line and maven will generate the following artifacts:
+
+API::
+A jar containing the api annotations, etc. in `/api/target`
+
+Specification::
+A PDF and HTML version of the specification document in `/spec/target/generated-docs/`
+
+TCK::
+A artifacts to test an implementation in `/tck/target`

--- a/proposals/problem-details/api/pom.xml
+++ b/proposals/problem-details/api/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019 Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.microprofile.sandbox</groupId>
+        <artifactId>problem-details-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>problem-details-api</artifactId>
+    <name>MicroProfile Problem Details :: API</name>
+    <description>Problem Details for MicroProfile :: API</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Constants.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Constants.java
@@ -1,0 +1,31 @@
+package org.eclipse.microprofile.problemdetails;
+
+import javax.ws.rs.core.MediaType;
+
+public class Constants {
+    /**
+     * The JSON formatted details body of a failing http request.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7807">RFC-7807</a>
+     */
+    public static final String PROBLEM_DETAIL_JSON = "application/problem+json";
+    /**
+     * The JSON formatted details body of a failing http request.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7807">RFC-7807</a>
+     */
+    public static final MediaType PROBLEM_DETAIL_JSON_TYPE = MediaType.valueOf(PROBLEM_DETAIL_JSON);
+
+    /**
+     * The XML formatted details body of a failing http request.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7807">RFC-7807</a>
+     */
+    public static final String PROBLEM_DETAIL_XML = "application/problem+xml";
+    /**
+     * The XML formatted details body of a failing http request.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7807">RFC-7807</a>
+     */
+    public static final MediaType PROBLEM_DETAIL_XML_TYPE = MediaType.valueOf(PROBLEM_DETAIL_XML);
+}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Detail.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Detail.java
@@ -1,0 +1,19 @@
+package org.eclipse.microprofile.problemdetails;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated methods or fields are used to build the <code>detail</code>
+ * field of the problem detail. Multiple details are joined to a single string
+ * delimited by `. `: a period and a space character.
+ * <p>
+ * Defaults to the message of the exception.
+ */
+@Retention(RUNTIME)
+@Target({METHOD, FIELD})
+public @interface Detail {}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Extension.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Extension.java
@@ -1,0 +1,20 @@
+package org.eclipse.microprofile.problemdetails;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated methods or fields are used to build additional properties of the problem detail.
+ */
+@Retention(RUNTIME)
+@Target({METHOD, FIELD})
+public @interface Extension {
+    /**
+     * Defaults to the field/method name
+     */
+    String value() default "";
+}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Instance.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Instance.java
@@ -1,0 +1,20 @@
+package org.eclipse.microprofile.problemdetails;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated method or field is used for the <code>instance</code> field of the problem detail.
+ * The behavior is undefined, if there are multiple fields/methods.
+ * Note that this value should be different for every occurrence.
+ * <p>
+ * By default, an <code>URN</code> with <code>urn:uuid:</code> and a random {@link java.util.UUID}
+ * is generated.
+ */
+@Retention(RUNTIME)
+@Target({METHOD, FIELD})
+public @interface Instance {}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/LogLevel.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/LogLevel.java
@@ -1,0 +1,10 @@
+package org.eclipse.microprofile.problemdetails;
+
+public enum LogLevel {
+    /**
+     * <code>DEBUG</code> for <code>4xx</code> and <code>ERROR</code> for <code>5xx</code> and anything else.
+     */
+    AUTO,
+
+    ERROR, WARNING, INFO, DEBUG, OFF
+}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Logging.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Logging.java
@@ -1,0 +1,30 @@
+package org.eclipse.microprofile.problemdetails;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.eclipse.microprofile.problemdetails.LogLevel.AUTO;
+
+/**
+ * Defines how problem details should be logged.
+ * <p>
+ * Can be applied to the package level, so all exceptions in the package are configured by default.
+ */
+@Retention(RUNTIME)
+@Target({TYPE, PACKAGE})
+public @interface Logging {
+
+    /**
+     * The category to log to. Defaults to the fully qualified class name of the exception.
+     */
+    String to() default "";
+
+    /**
+     * The level to log at. Defaults to <code>AUTO</code>, i.e. <code>DEBUG</code> for <code>4xx</code>
+     * and <code>ERROR</code> for <code>5xx</code>.
+     */
+    LogLevel at() default AUTO;
+}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Status.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Status.java
@@ -1,0 +1,19 @@
+package org.eclipse.microprofile.problemdetails;
+
+import javax.ws.rs.core.Response;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Defines the http status code to be used for the annotated exception.
+ * This will also be included as the <code>status</code> field of the
+ * problem detail.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Status {
+    Response.Status value();
+}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Title.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Title.java
@@ -1,0 +1,18 @@
+package org.eclipse.microprofile.problemdetails;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Defines the title string to be used for the annotated exception.
+ * The default is derived from the simple class name by splitting the
+ * camel case name into words.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Title {
+    String value();
+}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Type.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/Type.java
@@ -1,0 +1,17 @@
+package org.eclipse.microprofile.problemdetails;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Defines the type url to be used for the annotated exception.
+ * The default is a URN <code>urn:problem-type:[simple-class-name-with-dashes]</code>
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Type {
+    String value();
+}

--- a/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/package-info.java
+++ b/proposals/problem-details/api/src/main/java/org/eclipse/microprofile/problemdetails/package-info.java
@@ -1,0 +1,43 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+/**
+ * Annotations to override the default values for RFC-7807 problem detail fields, for example:
+ * <pre>
+ *{@literal @}Type("https://example.com/probs/out-of-credit")
+ *{@literal @}Title("You do not have enough credit.")
+ *{@literal @}Status(FORBIDDEN)
+ * public class OutOfCreditException extends RuntimeException {
+ *    {@literal @}Instance private URI instance;
+ *    {@literal @}Extension private int balance;
+ *     private int cost;
+ *    {@literal @}Extension private List<URI> accounts;
+ *
+ *    {@literal @}Detail public String getDetail() {
+ *         return "Your current balance is " + balance + ", but that costs " + cost + ".";
+ *     }
+ *
+ *     // ... constructors & getters
+ * }
+ * </pre>
+ *
+ * @since 1.0
+ */
+package org.eclipse.microprofile.problemdetails;

--- a/proposals/problem-details/pom.xml
+++ b/proposals/problem-details/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019 Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.microprofile.sandbox</groupId>
+    <artifactId>problem-details-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>MicroProfile Problem Details</name>
+    <description>RFC-7807 compliant Problem Detail handling for Java on the http server as well as on the client side</description>
+    <url>http://microprofile.io</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>Eclipse Foundation</name>
+        <url>http://www.eclipse.org/</url>
+    </organization>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/eclipse/microprofile-sandbox/issues</url>
+    </issueManagement>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse/microprofile-sandbox.git</connection>
+        <developerConnection>scm:git:git@github.com:eclipse/microprofile-sandbox.git</developerConnection>
+        <url>https://github.com/eclipse/microprofile-sandbox/proposals/problem-details</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>MicroProfile Community</name>
+            <url>http://microprofile.io/</url>
+            <organization>Eclipse Foundation</organization>
+        </developer>
+    </developers>
+
+    <modules>
+        <module>spec</module>
+        <module>api</module>
+        <module>tck</module>
+    </modules>
+
+    <build>
+        <defaultGoal>install</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/proposals/problem-details/spec/pom.xml
+++ b/proposals/problem-details/spec/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019 Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.microprofile.sandbox</groupId>
+        <artifactId>problem-details-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>problem-details-spec</artifactId>
+    <packaging>pom</packaging>
+    <name>MicroProfile Problem Details :: Spec</name>
+    <description>Problem Details for MicroProfile :: Specification</description>
+
+    <properties>
+        <asciidoctor-revision-date>${maven.build.timestamp}</asciidoctor-revision-date>
+        <asciidoctor-revision-remark>Draft</asciidoctor-revision-remark>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>1.5.7.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-pdf</artifactId>
+                        <version>1.5.0-alpha.16</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>generate-pdf-doc</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>pdf</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${asciidoctor-revision-remark}</revremark>
+                                <revdate>${asciidoctor-revision-date}</revdate>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>output-html</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${asciidoctor-revision-remark}</revremark>
+                                <revdate>${asciidoctor-revision-date}</revdate>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/proposals/problem-details/spec/src/main/asciidoc/microprofile-problemdetails.asciidoc
+++ b/proposals/problem-details/spec/src/main/asciidoc/microprofile-problemdetails.asciidoc
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+= MicroProfile Problem Details
+:authors: Rüdiger zu Dohna
+:email: ruediger.dohna@codecentric.de
+:version-label!:
+:sectanchors:
+:doctype: book
+:license: Apache License v2.0
+:source-highlighter: coderay
+:icons: font
+:numbered:
+:toc: left
+:toclevels: 4
+:sectnumlevels: 4
+ifdef::backend-pdf[]
+:pagenums:
+endif::[]
+
+== Introduction
+
+* MUST `application/problem+json`, `application/problem+xml`; SHOULD any, e.g. `+yaml`
+* SHOULD render `text/html`
+* map also `@Valid` REST params
+* logging: 4xx = DEBUG, 5xx = ERROR; configurable?
+* order of extensions is alphabetic (which is better for tests than random)
+* multiple extensions with the same name: undefined behavior
+* JAXB can't unmarshal a subclass with the same type and namespace
+
+== Fields
+
+=== Type
+
+=== Title
+
+=== Detail
+
+=== Status
+
+=== Instance
+
+=== Extension
+
+== Logging
+
+== Security Considerations
+
+* Security considerations: nothing dangerous in problem details (i.e. exception message); stack-trace in logs

--- a/proposals/problem-details/tck/README.asciidoc
+++ b/proposals/problem-details/tck/README.asciidoc
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2019 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+= Running the MicroProfile Problem Detail TCK
+
+//TODO: document how to run the TCK
+
+`-Dtestcontainer-running=http://localhost:8080/problem-details-tck`

--- a/proposals/problem-details/tck/pom.xml
+++ b/proposals/problem-details/tck/pom.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019 Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.microprofile.sandbox</groupId>
+        <artifactId>problem-details-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>problem-details-tck</artifactId>
+    <packaging>war</packaging>
+    <name>MicroProfile Problem Details :: TCK</name>
+    <description>Problem Details for MicroProfile :: TCK</description>
+
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+
+        <resteasy.version>4.4.2.Final</resteasy.version>
+        <slf4j.version>1.7.30</slf4j.version>
+    </properties>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.microprofile.sandbox</groupId>
+            <artifactId>problem-details-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>1.3.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>2.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>1.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.14.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.t1</groupId>
+            <artifactId>jee-testcontainers</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core-spi</artifactId>
+            <version>${resteasy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-undertow</artifactId>
+            <version>${resteasy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>${resteasy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client-microprofile</artifactId>
+            <version>${resteasy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.1.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>2.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>problem-details-ri</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.microprofile.sandbox</groupId>
+                    <artifactId>problem-details-api</artifactId>
+                    <version>${project.version}</version>
+                    <!-- not provided -->
+                </dependency>
+                <dependency>
+                    <groupId>com.github.t1</groupId>
+                    <artifactId>problem-details-ri</artifactId>
+                    <version>1.1.0-SNAPSHOT</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>with-slf4j</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                    <version>${slf4j.version}</version>
+                    <!-- not provided -->
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                    <version>${slf4j.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/BridgeBoundary.java
+++ b/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/BridgeBoundary.java
@@ -1,0 +1,111 @@
+package org.eclipse.microprofile.problemdetails.tckapp;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import java.net.URI;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+@Slf4j
+@Path("/bridge")
+public class BridgeBoundary {
+    private static final String BASE_URI = "http://localhost:8080/problem-details-tck";
+    private static final Entity<String> EMPTY = Entity.entity("{}", APPLICATION_JSON_TYPE);
+
+    /** how to call the target */
+    public enum Mode {
+        /** JAX-RS WebTarget */
+        jaxRs,
+
+        /** Manually build a Microprofile Rest Client */
+        mMpRest,
+
+        /** Injected Microprofile Rest Client */
+        iMpRest
+    }
+
+    /** how should the target behave */
+    public enum State {ok, fails}
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    public static class Reply {
+        private String value;
+    }
+
+    public static class ApiException extends IllegalArgumentException {}
+
+    @Inject @RestClient API target;
+
+    private final Client rest = ClientBuilder.newClient();
+
+    @RegisterRestClient(baseUri = BASE_URI)
+    public interface API {
+        @Path("/bridge/target/{state}")
+        @GET Reply request(@PathParam("state") State state) throws ApiException;
+    }
+
+    @Path("/indirect/{state}")
+    @GET public Reply indirect(@PathParam("state") State state, @NotNull @QueryParam("mode") Mode mode) {
+        log.debug("call indirect {} :: {}", state, mode);
+
+        API target = target(mode);
+
+        try {
+            Reply reply = target.request(state);
+            log.debug("indirect call reply {}", reply);
+            return reply;
+        } catch (RuntimeException e) {
+            log.debug("indirect call exception", e);
+            throw e;
+        }
+    }
+
+    private API target(@QueryParam("mode") Mode mode) {
+        switch (mode) {
+            case jaxRs:
+                return this::jaxRsCall;
+            case mMpRest:
+                return RestClientBuilder.newBuilder().baseUri(URI.create(BASE_URI)).build(API.class);
+            case iMpRest:
+                return this.target;
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    private Reply jaxRsCall(State state) {
+        // ProblemDetailExceptionRegistry.register(ApiException.class);
+        return rest.target(BASE_URI)
+            // .register(ProblemDetailClientResponseFilter.class)
+            .path("/bridge/target")
+            .path(state.toString())
+            .request(APPLICATION_JSON_TYPE)
+            .get(Reply.class);
+    }
+
+    @Path("/target/{state}")
+    @GET public Reply target(@PathParam("state") State state) {
+        log.debug("target {}", state);
+        switch (state) {
+            case ok:
+                return new Reply("okay");
+            case fails:
+                throw new ApiException();
+        }
+        throw new UnsupportedOperationException();
+    }
+}

--- a/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/Config.java
+++ b/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/Config.java
@@ -1,0 +1,7 @@
+package org.eclipse.microprofile.problemdetails.tckapp;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class Config extends Application {}

--- a/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/CustomExceptionBoundary.java
+++ b/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/CustomExceptionBoundary.java
@@ -1,0 +1,183 @@
+package org.eclipse.microprofile.problemdetails.tckapp;
+
+import org.eclipse.microprofile.problemdetails.Detail;
+import org.eclipse.microprofile.problemdetails.Extension;
+import org.eclipse.microprofile.problemdetails.Instance;
+import org.eclipse.microprofile.problemdetails.Status;
+import org.eclipse.microprofile.problemdetails.Title;
+import org.eclipse.microprofile.problemdetails.Type;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.net.URI;
+
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+
+@Path("/custom")
+public class CustomExceptionBoundary {
+    @Path("/runtime-exception")
+    @POST public void customRuntimeException() {
+        class CustomException extends RuntimeException {}
+        throw new CustomException();
+    }
+
+    @Path("/illegal-argument-exception")
+    @POST public void customIllegalArgumentException() {
+        class CustomException extends IllegalArgumentException {}
+        throw new CustomException();
+    }
+
+    @Path("/explicit-type")
+    @POST public void customTypeException() {
+        @Type("http://error-codes.org/out-of-memory")
+        class SomeException extends RuntimeException {}
+        throw new SomeException();
+    }
+
+    @Path("/explicit-title")
+    @POST public void customTitleException() {
+        @Title("Some Title")
+        class SomeException extends RuntimeException {}
+        throw new SomeException();
+    }
+
+    @Path("/explicit-status")
+    @POST public void customExplicitStatus() {
+        @Status(FORBIDDEN)
+        class SomethingForbiddenException extends RuntimeException {}
+        throw new SomethingForbiddenException();
+    }
+
+    @Path("/public-detail-method")
+    @POST public void publicDetailMethod() {
+        class SomeMessageException extends RuntimeException {
+            @Detail public String detail() { return "some detail"; }
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/private-detail-method")
+    @POST public void privateDetailMethod() {
+        class SomeMessageException extends RuntimeException {
+            @Detail private String detail() { return "some detail"; }
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/failing-detail-method")
+    @POST public void failingDetailMethod() {
+        class FailingDetailException extends RuntimeException {
+            public FailingDetailException() { super("some message"); }
+
+            @Detail public String failingDetail() {
+                throw new RuntimeException("inner");
+            }
+        }
+        throw new FailingDetailException();
+    }
+
+    @Path("/public-detail-field")
+    @POST public void publicDetailField() {
+        class SomeMessageException extends RuntimeException {
+            @Detail public String detail = "some detail";
+
+            public SomeMessageException(String message) {
+                super(message);
+            }
+        }
+        throw new SomeMessageException("overwritten");
+    }
+
+    @Path("/private-detail-field")
+    @POST public void privateDetailField() {
+        class SomeMessageException extends RuntimeException {
+            @Detail private String detail = "some detail";
+
+            public SomeMessageException(String message) {
+                super(message);
+            }
+        }
+        throw new SomeMessageException("overwritten");
+    }
+
+    @Path("/multi-detail-fields")
+    @POST public void multiDetailField() {
+        class SomeMessageException extends RuntimeException {
+            @Detail public String detail1 = "detail a";
+            @Detail public String detail2 = "detail b";
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/mixed-details")
+    @POST public void multiDetails() {
+        class SomeMessageException extends RuntimeException {
+            @Detail public String detail0() { return "detail a"; }
+
+            @Detail public String detail1 = "detail b";
+            @Detail public String detail2 = "detail c";
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/detail-method-arg")
+    @POST public void detailMethodArg() {
+        class SomeMessageException extends RuntimeException {
+            @Detail public String detail(String foo) { return "some " + foo; }
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/explicit-uri-instance")
+    @POST public void customInstanceException() {
+        class SomeException extends RuntimeException {
+            @Instance URI instance() { return URI.create("foobar"); }
+        }
+        throw new SomeException();
+    }
+
+    @Path("/extension-method")
+    @POST public void customExtensionMethod() {
+        class SomeException extends RuntimeException {
+            @Extension public String ex() { return "some extension"; }
+        }
+        throw new SomeException();
+    }
+
+    @Path("/extension-method-with-name")
+    @POST public void customExtensionMethodWithExplicitName() {
+        class SomeMessageException extends RuntimeException {
+            @Extension("foo") public String ex() { return "some extension"; }
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/extension-field")
+    @POST public void customExtensionField() {
+        class SomeMessageException extends RuntimeException {
+            @Extension public String ex = "some extension";
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/extension-field-with-name")
+    @POST public void customExtensionFieldWithName() {
+        class SomeMessageException extends RuntimeException {
+            @Extension("foo") public String ex = "some extension";
+        }
+        throw new SomeMessageException();
+    }
+
+    @Path("/multi-extension")
+    @POST public void multiExtension() {
+        class SomeMessageException extends RuntimeException {
+            @Extension String m1() { return "method 1"; }
+
+            @Extension("m2") String method() { return "method 2"; }
+
+            @Extension String f1 = "field 1";
+            @Extension("f2") String field = "field 2";
+        }
+        throw new SomeMessageException();
+    }
+}

--- a/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/StandardExceptionBoundary.java
+++ b/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/StandardExceptionBoundary.java
@@ -1,0 +1,54 @@
+package org.eclipse.microprofile.problemdetails.tckapp;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+@Path("/standard")
+public class StandardExceptionBoundary {
+    @Path("/plain-bad-request")
+    @POST public void plainBadRequest() {
+        throw new BadRequestException();
+    }
+
+    @Path("/bad-request-with-message")
+    @POST public void badRequestWithMessage() {
+        throw new BadRequestException("some message");
+    }
+
+    @Path("/bad-request-with-text-response")
+    @POST public void badRequestWithResponse() {
+        throw new BadRequestException(Response.status(BAD_REQUEST)
+            .type(TEXT_PLAIN_TYPE).entity("the body").build());
+    }
+
+    @Path("/plain-service-unavailable")
+    @POST public void plainServiceUnavailable() {
+        throw new ServiceUnavailableException();
+    }
+
+    @Path("/illegal-argument-without-message")
+    @POST public void illegalArgumentWithoutMessage() {
+        throw new IllegalArgumentException();
+    }
+
+    @Path("/illegal-argument-with-message")
+    @POST public void illegalArgumentWithMessage() {
+        throw new IllegalArgumentException("some message");
+    }
+
+    @Path("/npe-without-message")
+    @POST public void npeWithoutMessage() {
+        throw new NullPointerException();
+    }
+
+    @Path("/npe-with-message")
+    @POST public void npeWithMessage() {
+        throw new NullPointerException("some message");
+    }
+}

--- a/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/ValidationBoundary.java
+++ b/proposals/problem-details/tck/src/main/java/org/eclipse/microprofile/problemdetails/tckapp/ValidationBoundary.java
@@ -1,0 +1,39 @@
+package org.eclipse.microprofile.problemdetails.tckapp;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.Positive;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.time.LocalDate;
+import java.util.List;
+
+@Path("/validation")
+public class ValidationBoundary {
+    @Value
+    @NoArgsConstructor(force = true) @AllArgsConstructor
+    public static class Address {
+        @NotNull String street;
+        @Positive int zipCode;
+        @NotNull String city;
+    }
+
+    @Value
+    @NoArgsConstructor(force = true) @AllArgsConstructor
+    public static class Person {
+        @NotNull String firstName;
+        @NotEmpty String lastName;
+        @Past LocalDate born;
+        @Valid List<Address> address;
+    }
+
+    @POST public String post(@Valid Person person) {
+        return "valid:" + person;
+    }
+}

--- a/proposals/problem-details/tck/src/test/java/test/ContainerLaunchingExtension.java
+++ b/proposals/problem-details/tck/src/test/java/test/ContainerLaunchingExtension.java
@@ -1,0 +1,167 @@
+package test;
+
+import com.github.t1.testcontainers.jee.JeeContainer;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
+import java.util.function.Consumer;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContainerLaunchingExtension implements Extension, BeforeAllCallback {
+    private static URI BASE_URI = null;
+
+    /**
+     * Stopping is done by the ryuk container... see
+     * https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers
+     */
+    @Override public void beforeAll(ExtensionContext context) {
+        if (System.getProperty("testcontainer-running") != null) {
+            BASE_URI = URI.create(System.getProperty("testcontainer-running"));
+        } else if (BASE_URI == null) {
+            JeeContainer container = JeeContainer.create()
+                .withDeployment("target/problem-details-test.war");
+            container.start();
+            BASE_URI = container.baseUri();
+        }
+    }
+
+    public static ProblemDetailAssert<ProblemDetail> testPost(String path) {
+        return thenProblemDetail(post(path));
+    }
+
+    public static <T extends ProblemDetail> ProblemDetailAssert<T> testPost(String path, Class<T> type) {
+        return thenProblemDetail(post(path), type);
+    }
+
+    public static ProblemDetailAssert<ProblemDetail> testPost(String path, String accept) {
+        return thenProblemDetail(target(path).request(MediaType.valueOf(accept)).post(null));
+    }
+
+    public static ProblemDetailAssert<ProblemDetail> testPost(String path, String accept1, String accept2) {
+        return thenProblemDetail(target(path).request(MediaType.valueOf(accept1), MediaType.valueOf(accept2)).post(null));
+    }
+
+    public static <T> ResponseAssert<T> testPost(String path, String accept, Class<T> type) {
+        return new ResponseAssert<>(target(path).request(MediaType.valueOf(accept)).post(null), type);
+    }
+
+    public static Response post(String path) {
+        return target(path).request(APPLICATION_JSON_TYPE).post(null);
+    }
+
+    public static WebTarget target(String path) {
+        return target().path(path);
+    }
+
+    private static final Client CLIENT = ClientBuilder.newClient();
+
+    public static WebTarget target() {
+        return CLIENT.target(BASE_URI);
+    }
+
+    public static ProblemDetailAssert<ProblemDetail> thenProblemDetail(Response response) {
+        return thenProblemDetail(response, ProblemDetail.class);
+    }
+
+    public static <T extends ProblemDetail> ProblemDetailAssert<T> thenProblemDetail(Response response, Class<T> type) {
+        return new ProblemDetailAssert<>(response, type);
+    }
+
+    public static class ProblemDetailAssert<T extends ProblemDetail> extends ResponseAssert<T> {
+        public ProblemDetailAssert(Response response, Class<T> type) { super(response, type); }
+
+        @Override public ProblemDetailAssert<T> hasStatus(Status status) {
+            super.hasStatus(status);
+            assertThat(entity.getStatus()).describedAs("problem-detail.status")
+                .isEqualTo(status.getStatusCode());
+            return this;
+        }
+
+        @Override public ProblemDetailAssert<T> hasContentType(String contentType) {
+            super.hasContentType(contentType);
+            return this;
+        }
+
+        @Override public ProblemDetailAssert<T> hasContentType(MediaType contentType) {
+            super.hasContentType(contentType);
+            return this;
+        }
+
+
+        public ProblemDetailAssert<T> hasType(String type) {
+            assertThat(entity.getType()).describedAs("problem-detail.type")
+                .isEqualTo(URI.create(type));
+            return this;
+        }
+
+        public ProblemDetailAssert<T> hasTitle(String title) {
+            assertThat(entity.getTitle()).describedAs("problem-detail.title")
+                .isEqualTo(title);
+            return this;
+        }
+
+        public ProblemDetailAssert<T> hasDetail(String detail) {
+            assertThat(getDetail()).describedAs("problem-detail.detail")
+                .isEqualTo(detail);
+            return this;
+        }
+
+        public String getDetail() {
+            return entity.getDetail();
+        }
+
+        public ProblemDetailAssert<T> hasUuidInstance() {
+            assertThat(entity.getInstance()).describedAs("problem-detail.instance")
+                .has(new Condition<>(instance -> instance.toString().startsWith("urn:uuid:"), "some uuid urn"));
+            return this;
+        }
+
+        public void check(Consumer<T> consumer) {
+            consumer.accept(entity);
+        }
+    }
+
+    public static class ResponseAssert<T> {
+        protected final Response response;
+        protected final T entity;
+
+        public ResponseAssert(Response response, Class<T> type) {
+            this.response = response;
+            assertThat(this.response.hasEntity()).describedAs("response has entity").isTrue();
+            this.entity = this.response.readEntity(type);
+        }
+
+        public ResponseAssert<T> hasStatus(Status status) {
+            assertThat(response.getStatusInfo()).describedAs("response status")
+                .isEqualTo(status);
+            return this;
+        }
+
+        public ResponseAssert<T> hasContentType(String contentType) {
+            return hasContentType(MediaType.valueOf(contentType));
+        }
+
+        public ResponseAssert<T> hasContentType(MediaType contentType) {
+            assertThat(response.getMediaType().isCompatible(contentType))
+                .describedAs("response content type [" + response.getMediaType() + "] "
+                    + "is not compatible with [" + contentType + "]").isTrue();
+            return this;
+        }
+
+        @SuppressWarnings("UnusedReturnValue") public ResponseAssert<T> hasBody(T entity) {
+            assertThat(this.entity).isEqualTo(entity);
+            return this;
+        }
+    }
+}

--- a/proposals/problem-details/tck/src/test/java/test/CustomExceptionIT.java
+++ b/proposals/problem-details/tck/src/test/java/test/CustomExceptionIT.java
@@ -1,0 +1,145 @@
+package test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.eclipse.microprofile.problemdetails.Constants.PROBLEM_DETAIL_JSON;
+import static test.ContainerLaunchingExtension.testPost;
+
+@ExtendWith(ContainerLaunchingExtension.class)
+class CustomExceptionIT {
+
+    @Test void shouldMapCustomRuntimeException() {
+        testPost("/custom/runtime-exception")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:custom")
+            .hasTitle("Custom")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapCustomIllegalArgumentException() {
+        testPost("/custom/illegal-argument-exception")
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:custom")
+            .hasTitle("Custom")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapExplicitType() {
+        testPost("/custom/explicit-type")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("http://error-codes.org/out-of-memory")
+            .hasTitle("Some")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapExplicitTitle() {
+        testPost("/custom/explicit-title")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some")
+            .hasTitle("Some Title")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapExplicitStatus() {
+        testPost("/custom/explicit-status")
+            .hasStatus(FORBIDDEN)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:something-forbidden")
+            .hasTitle("Something Forbidden")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+
+    @Test void shouldMapDetailMethod() {
+        testPost("/custom/public-detail-method")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail("some detail")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapPrivateDetailMethod() {
+        testPost("/custom/private-detail-method")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail("some detail")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapFailingDetailMethod() {
+        testPost("/custom/failing-detail-method")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:failing-detail")
+            .hasTitle("Failing Detail")
+            .hasDetail("could not invoke FailingDetailException.failingDetail: java.lang.RuntimeException: inner")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapPublicDetailFieldOverridingMessage() {
+        testPost("/custom/public-detail-field")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail("some detail")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapPrivateDetailField() {
+        testPost("/custom/private-detail-field")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail("some detail")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapMultipleDetailFields() {
+        testPost("/custom/multi-detail-fields")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail("detail a. detail b")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapDetailMethodAndTwoFields() {
+        testPost("/custom/mixed-details")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail("detail a. detail b. detail c")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldFailToMapDetailMethodTakingAnArgument() {
+        testPost("/custom/detail-method-arg")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail("could not invoke SomeMessageException.detail: expected no args but got 1")
+            .hasUuidInstance();
+    }
+}

--- a/proposals/problem-details/tck/src/test/java/test/ExtensionMappingIT.java
+++ b/proposals/problem-details/tck/src/test/java/test/ExtensionMappingIT.java
@@ -1,0 +1,93 @@
+package test;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.eclipse.microprofile.problemdetails.Constants.PROBLEM_DETAIL_JSON;
+import static test.ContainerLaunchingExtension.testPost;
+
+@ExtendWith(ContainerLaunchingExtension.class)
+class ExtensionMappingIT {
+
+    @Test void shouldMapExtensionStringMethod() {
+        testPost("/custom/extension-method", ProblemDetailWithExtensionString.class)
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some")
+            .hasTitle("Some")
+            .hasDetail(null)
+            .hasUuidInstance()
+            .check(detail -> then(detail.ex).isEqualTo("some extension"));
+    }
+
+    @Test void shouldMapExtensionStringMethodWithAnnotatedName() {
+        testPost("/custom/extension-method-with-name", ProblemDetailWithExtensionStringFoo.class)
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail(null)
+            .hasUuidInstance()
+            .check(detail -> then(detail.foo).isEqualTo("some extension"));
+    }
+
+    @Test void shouldMapExtensionStringField() {
+        testPost("/custom/extension-field", ProblemDetailWithExtensionString.class)
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail(null)
+            .hasUuidInstance()
+            .check(detail -> then(detail.ex).isEqualTo("some extension"));
+    }
+
+    @Test void shouldMapExtensionStringFieldWithAnnotatedName() {
+        testPost("/custom/extension-field-with-name", ProblemDetailWithExtensionStringFoo.class)
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail(null)
+            .hasUuidInstance()
+            .check(detail -> then(detail.foo).isEqualTo("some extension"));
+    }
+
+    @Test void shouldMapMultiplePackagePrivateExtensions() {
+        testPost("/custom/multi-extension", ProblemDetailWithMultipleExtensions.class)
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:some-message")
+            .hasTitle("Some Message")
+            .hasDetail(null)
+            .hasUuidInstance()
+            .check(detail -> {
+                then(detail.m1).isEqualTo("method 1");
+                then(detail.m2).isEqualTo("method 2");
+                then(detail.f1).isEqualTo("field 1");
+                then(detail.f2).isEqualTo("field 2");
+            });
+    }
+
+    @Data @EqualsAndHashCode(callSuper = true)
+    public static class ProblemDetailWithExtensionString extends ProblemDetail {
+        private String ex;
+    }
+
+    @Data @EqualsAndHashCode(callSuper = true)
+    public static class ProblemDetailWithExtensionStringFoo extends ProblemDetail {
+        private String foo;
+    }
+
+    @Data @EqualsAndHashCode(callSuper = true)
+    public static class ProblemDetailWithMultipleExtensions extends ProblemDetail {
+        private String m1;
+        private String m2;
+        private String f1;
+        private String f2;
+    }
+}

--- a/proposals/problem-details/tck/src/test/java/test/MicroprofileRestClientBridgeIT.java
+++ b/proposals/problem-details/tck/src/test/java/test/MicroprofileRestClientBridgeIT.java
@@ -1,0 +1,63 @@
+package test;
+
+import org.eclipse.microprofile.problemdetails.tckapp.BridgeBoundary;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.eclipse.microprofile.problemdetails.Constants.PROBLEM_DETAIL_JSON_TYPE;
+import static test.ContainerLaunchingExtension.target;
+import static test.ContainerLaunchingExtension.thenProblemDetail;
+
+@ExtendWith(ContainerLaunchingExtension.class)
+class MicroprofileRestClientBridgeIT {
+
+    @Test void shouldFailValidationWithoutMode() {
+        Response response = get("/bridge/indirect/ok", null);
+
+        thenProblemDetail(response).hasType("urn:problem-type:validation-failed");
+    }
+
+    @EnumSource(BridgeBoundary.Mode.class)
+    @ParameterizedTest void shouldFailWithUnknownState(BridgeBoundary.Mode mode) {
+        Response response = get("/bridge/indirect/unknown", mode);
+
+        thenProblemDetail(response).hasStatus(NOT_FOUND).hasType("urn:problem-type:not-found");
+    }
+
+    @EnumSource(BridgeBoundary.Mode.class)
+    @ParameterizedTest void shouldMapBridgedOkay(BridgeBoundary.Mode mode) {
+        Response response = get("/bridge/indirect/ok", mode);
+
+        then(response.getStatusInfo()).isEqualTo(OK);
+        then(response.getMediaType()).isEqualTo(APPLICATION_JSON_TYPE);
+        then(response.readEntity(String.class)).isEqualTo("{\"value\":\"okay\"}");
+    }
+
+    @EnumSource(BridgeBoundary.Mode.class)
+    @ParameterizedTest void shouldMapBridgedFail(BridgeBoundary.Mode mode) {
+        Response response = get("/bridge/indirect/fails", mode);
+
+        thenProblemDetail(response)
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(PROBLEM_DETAIL_JSON_TYPE)
+            .hasTitle("Api")
+            .hasType("urn:problem-type:api")
+            .hasUuidInstance();
+    }
+
+    private Response get(String path, BridgeBoundary.Mode mode) {
+        return target(path)
+            .queryParam("mode", mode)
+            .request(APPLICATION_JSON_TYPE)
+            .get();
+    }
+}

--- a/proposals/problem-details/tck/src/test/java/test/ProblemDetail.java
+++ b/proposals/problem-details/tck/src/test/java/test/ProblemDetail.java
@@ -1,0 +1,17 @@
+package test;
+
+import lombok.Data;
+
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+
+@Data
+public class ProblemDetail {
+    public static final MediaType JSON_MEDIA_TYPE = MediaType.valueOf("application/problem+json");
+
+    private URI type;
+    private String title;
+    private String detail;
+    private Integer status;
+    private URI instance;
+}

--- a/proposals/problem-details/tck/src/test/java/test/StandardExceptionMappingIT.java
+++ b/proposals/problem-details/tck/src/test/java/test/StandardExceptionMappingIT.java
@@ -1,0 +1,123 @@
+package test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static org.eclipse.microprofile.problemdetails.Constants.PROBLEM_DETAIL_JSON;
+import static org.eclipse.microprofile.problemdetails.Constants.PROBLEM_DETAIL_XML;
+import static test.ContainerLaunchingExtension.testPost;
+
+@ExtendWith(ContainerLaunchingExtension.class)
+class StandardExceptionMappingIT {
+    // TODO TomEE doesn't write some problem detail entities https://github.com/t1/problem-details/issues/17
+    @DisabledIfSystemProperty(named = "jee-testcontainer", matches = "tomee")
+    @Test void shouldMapClientWebApplicationExceptionWithoutEntityOrMessage() {
+        testPost("standard/plain-bad-request")
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:bad-request")
+            .hasTitle("Bad Request")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    // TODO TomEE doesn't write some problem detail entities https://github.com/t1/problem-details/issues/17
+    @DisabledIfSystemProperty(named = "jee-testcontainer", matches = "tomee")
+    @Test void shouldMapClientWebApplicationExceptionWithoutEntityButMessage() {
+        testPost("/standard/bad-request-with-message")
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:bad-request")
+            .hasTitle("Bad Request")
+            .hasDetail("some message")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldUseEntityFromWebApplicationException() {
+        testPost("/standard/bad-request-with-text-response", TEXT_PLAIN, String.class)
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(TEXT_PLAIN)
+            .hasBody("the body");
+    }
+
+    // TODO TomEE doesn't write some problem detail entities https://github.com/t1/problem-details/issues/17
+    @DisabledIfSystemProperty(named = "jee-testcontainer", matches = "tomee")
+    @Test void shouldMapServerWebApplicationExceptionWithoutEntityOrMessage() {
+        testPost("/standard/plain-service-unavailable")
+            .hasStatus(SERVICE_UNAVAILABLE)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:service-unavailable")
+            .hasTitle("Service Unavailable")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapIllegalArgumentExceptionWithoutMessage() {
+        testPost("/standard/illegal-argument-without-message")
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:illegal-argument")
+            .hasTitle("Illegal Argument")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapIllegalArgumentExceptionWithMessage() {
+        testPost("/standard/illegal-argument-with-message")
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:illegal-argument")
+            .hasTitle("Illegal Argument")
+            .hasDetail("some message")
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapNullPointerExceptionWithoutMessage() {
+        testPost("/standard/npe-without-message")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:null-pointer")
+            .hasTitle("Null Pointer")
+            .hasDetail(null)
+            .hasUuidInstance();
+    }
+
+    @Test void shouldMapNullPointerExceptionWithMessage() {
+        testPost("/standard/npe-with-message")
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:null-pointer")
+            .hasTitle("Null Pointer")
+            .hasDetail("some message")
+            .hasUuidInstance();
+    }
+
+    @Disabled
+    @Test void shouldMapToXml() {
+        testPost("/standard/npe-with-message", APPLICATION_XML)
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_XML)
+            .hasType("urn:problem-type:null-pointer")
+            .hasTitle("Null Pointer")
+            .hasDetail("some message")
+            .hasUuidInstance();
+    }
+
+    @Disabled
+    @Test void shouldMapToSecondAcceptXml() {
+        testPost("/standard/npe-with-message", TEXT_PLAIN, APPLICATION_XML)
+            .hasStatus(INTERNAL_SERVER_ERROR)
+            .hasContentType(PROBLEM_DETAIL_XML)
+            .hasType("urn:problem-type:null-pointer")
+            .hasTitle("Null Pointer")
+            .hasDetail("some message")
+            .hasUuidInstance();
+    }
+}

--- a/proposals/problem-details/tck/src/test/java/test/ValidationFailedExceptionMappingIT.java
+++ b/proposals/problem-details/tck/src/test/java/test/ValidationFailedExceptionMappingIT.java
@@ -1,0 +1,86 @@
+package test;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.assertj.core.api.BDDAssertions;
+import org.eclipse.microprofile.problemdetails.tckapp.ValidationBoundary.Address;
+import org.eclipse.microprofile.problemdetails.tckapp.ValidationBoundary.Person;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import test.ContainerLaunchingExtension.ProblemDetailAssert;
+
+import javax.ws.rs.core.Response;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Collections.singletonList;
+import static javax.ws.rs.client.Entity.entity;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.fail;
+import static org.eclipse.microprofile.problemdetails.Constants.PROBLEM_DETAIL_JSON;
+import static test.ContainerLaunchingExtension.target;
+import static test.ContainerLaunchingExtension.thenProblemDetail;
+
+@ExtendWith(ContainerLaunchingExtension.class)
+class ValidationFailedExceptionMappingIT {
+    @Test void shouldMapAnnotatedValidationFailedException() {
+        Person person = new Person(null, "", LocalDate.now().plusDays(3),
+            singletonList(new Address(null, -1, null)));
+
+        Response response = target("/validation").request(APPLICATION_JSON_TYPE)
+            .post(entity(person, APPLICATION_JSON_TYPE));
+
+        thenValidationFailed(response);
+    }
+
+    private void thenValidationFailed(Response response) {
+        ProblemDetailAssert<ValidationProblemDetail> it = thenProblemDetail(response, ValidationProblemDetail.class)
+            .hasStatus(BAD_REQUEST)
+            .hasContentType(PROBLEM_DETAIL_JSON)
+            .hasType("urn:problem-type:validation-failed")
+            .hasTitle("Validation Failed")
+            .hasUuidInstance();
+
+        String mustNotBeNull = mustOrMay(it) + " not be null";
+
+        switch (it.getDetail()) {
+            case "2 violations failed": // rest-easy has a different mode to validate fields
+                it.check(detail -> BDDAssertions.then(detail.violations).containsOnly(
+                    entry("post.person.firstName", mustNotBeNull),
+                    entry("post.person.lastName", "must not be empty")
+                ));
+                break;
+            case "6 violations failed":
+                it.check(detail -> BDDAssertions.then(detail.violations).containsOnly(
+                    entry("firstName", mustNotBeNull),
+                    entry("lastName", "must not be empty"),
+                    entry("born", "must be a past date"),
+                    entry("address[0].street", mustNotBeNull),
+                    entry("address[0].zipCode", "must be greater than 0"),
+                    entry("address[0].city", mustNotBeNull)
+                ));
+                break;
+            default:
+                fail("unexpected detail: [" + it.getDetail() + "]");
+        }
+    }
+
+    /** some validators say 'may' others say 'must' :( */
+    private String mustOrMay(ProblemDetailAssert<ValidationProblemDetail> it) {
+        AtomicBoolean containsMust = new AtomicBoolean(true);
+        it.check(detail -> {
+            if (detail.violations != null) {
+                containsMust.set(detail.violations.containsValue("must not be null"));
+            }
+        });
+        return containsMust.get() ? "must" : "may";
+    }
+
+    @Data @EqualsAndHashCode(callSuper = true)
+    public static class ValidationProblemDetail extends ProblemDetail {
+        private Map<String, String> violations;
+    }
+}

--- a/proposals/problem-details/tck/src/test/resources/logback-test.xml
+++ b/proposals/problem-details/tck/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="org.testcontainers.containers.output" level="INFO"/>
+    <logger name="org.jboss.resteasy.resteasy_jaxrs.i18n" level="INFO"/>
+</configuration>


### PR DESCRIPTION
I’d like to contribute a standard for better generation and handling of http message bodies for application error conditions. I’ve just blogged about it: https://blog.codecentric.de/en/2020/01/rfc-7807-problem-details-with-spring-boot-and-jax-rs/

**tl;dr**: exceptions get mapped to rfc-7807 compliant `application/problem+json` http bodies on the server side and/or back to exceptions on the client side. You can rely on useful defaults for the fields or annotate your exceptions when you have specific requirements.

I have a potential implementation [here](https://github.com/t1/problem-details) that runs on Payara and Open Liberty, and mostly on Widlfly 18... and on Spring Boot.

So the code is there, and I'm working on the spec text.

What do you say?
